### PR TITLE
Add Dockerfile for Python 3.12 FastAPI app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.12-slim
+
+# Install system packages
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl unzip gcc libffi-dev libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set work directory
+WORKDIR /app
+
+# Copy project
+COPY . /app
+
+# Install Python dependencies
+RUN pip install --no-cache-dir fastapi uvicorn[standard] pyinfra sqlmodel
+
+# Default command
+CMD ["fastapi", "dev", "main:app"]


### PR DESCRIPTION
## Summary
- add Dockerfile to containerize Sindri

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684a36764154832fa00166d30f25f3cf